### PR TITLE
Support for custom endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
-
-
 ## [0.14.1](https://github.com/arshad-yaseen/monacopilot/compare/v0.14.0...v0.14.1) (2024-11-13)
-
 
 ### 🔧 Maintenance
 
-* improve prompt nov-13 ([d7db8fc](https://github.com/arshad-yaseen/monacopilot/commit/d7db8fc59f85743d36ebc07098b293967c9087b7))
+- improve prompt nov-13 ([d7db8fc](https://github.com/arshad-yaseen/monacopilot/commit/d7db8fc59f85743d36ebc07098b293967c9087b7))
 
 ## [0.14.0](https://github.com/arshad-yaseen/monacopilot/compare/v0.13.2...v0.14.0) (2024-11-04)
 

--- a/src/classes/copilot.ts
+++ b/src/classes/copilot.ts
@@ -31,6 +31,7 @@ export class Copilot {
   private readonly apiKey: string;
   private provider: CopilotProvider;
   private model: CopilotModel | CustomCopilotModel;
+  private endpoint?: string;
 
   constructor(apiKey: string, options: CopilotOptions = {}) {
     if (!apiKey) {
@@ -40,6 +41,7 @@ export class Copilot {
     this.apiKey = apiKey;
     this.provider = options.provider ?? DEFAULT_COPILOT_PROVIDER;
     this.model = options.model ?? DEFAULT_COPILOT_MODEL;
+    this.endpoint = options.endpoint ?? undefined;
 
     this.validateInputs();
   }
@@ -63,6 +65,12 @@ export class Copilot {
         }" provider. Supported models: ${joinWithAnd(
           COPILOT_PROVIDER_MODEL_MAP[this.provider],
         )}`,
+      );
+    }
+
+    if (this.endpoint && this.endpoint.endsWith('/')) {
+      throw new Error(
+        `Endpoint URL should not end with a trailing slash: "${this.endpoint}".`,
       );
     }
   }
@@ -107,6 +115,7 @@ export class Copilot {
     headers: Record<string, string>;
   } {
     let endpoint = createProviderEndpoint(
+      this.endpoint,
       this.model as CopilotModel,
       this.apiKey,
       this.provider,

--- a/src/helpers/provider.ts
+++ b/src/helpers/provider.ts
@@ -10,13 +10,12 @@ import {
   ChatCompletionCreateParams,
   CopilotModel,
   CopilotProvider,
-  CustomCopilotModel,
   ProviderHandler,
 } from '../types';
 
 const openaiHandler: ProviderHandler<'openai'> = {
   /* Model and API key unused in this handler */
-  createEndpoint: () => COPILOT_PROVIDER_ENDPOINT_MAP.openai,
+  createEndpoint: endpoint => endpoint || COPILOT_PROVIDER_ENDPOINT_MAP.openai,
 
   createRequestBody: (model, prompt) => {
     const isO1Model = model === 'o1-preview' || model === 'o1-mini';
@@ -50,7 +49,7 @@ const openaiHandler: ProviderHandler<'openai'> = {
 
 const groqHandler: ProviderHandler<'groq'> = {
   /* Model and API key unused in this handler */
-  createEndpoint: () => COPILOT_PROVIDER_ENDPOINT_MAP.groq,
+  createEndpoint: endpoint => endpoint || COPILOT_PROVIDER_ENDPOINT_MAP.groq,
 
   createRequestBody: (model, prompt) => ({
     model: getModelId(model),
@@ -76,7 +75,8 @@ const groqHandler: ProviderHandler<'groq'> = {
 
 const anthropicHandler: ProviderHandler<'anthropic'> = {
   /* Model and API key unused in this handler */
-  createEndpoint: () => COPILOT_PROVIDER_ENDPOINT_MAP.anthropic,
+  createEndpoint: endpoint =>
+    endpoint || COPILOT_PROVIDER_ENDPOINT_MAP.anthropic,
 
   createRequestBody: (model, prompt) => ({
     model: getModelId(model),
@@ -113,8 +113,8 @@ const anthropicHandler: ProviderHandler<'anthropic'> = {
 };
 
 const googleHandler: ProviderHandler<'google'> = {
-  createEndpoint: (model, apiKey) =>
-    `${COPILOT_PROVIDER_ENDPOINT_MAP.google}/${model}:generateContent?key=${apiKey}`,
+  createEndpoint: (endpoint, model, apiKey) =>
+    `${endpoint || COPILOT_PROVIDER_ENDPOINT_MAP.google}/${model}:generateContent?key=${apiKey}`,
 
   createRequestBody: (model, prompt) => ({
     model: getModelId(model),
@@ -165,12 +165,13 @@ const providerHandlers: Record<
  * Creates an endpoint for different copilot providers.
  */
 export const createProviderEndpoint = (
+  endpoint: string | undefined,
   model: CopilotModel,
   apiKey: string,
   provider: CopilotProvider,
 ): string => {
   const handler = providerHandlers[provider];
-  return handler.createEndpoint(model, apiKey);
+  return handler.createEndpoint(endpoint, model, apiKey);
 };
 
 /**

--- a/src/types/copilot.ts
+++ b/src/types/copilot.ts
@@ -118,7 +118,7 @@ export interface CopilotOptions {
 
   /**
    * The endpoint to use. Can be used to override the default endpoint for the provider, without using a custom model.
-   * Mainly for things like Azure OpenAI or other providers that have multiple endpoints.
+   * Allows support for third-party providers that use familiar API structures.
    * If not specified, a default endpoint will be used.
    */
   endpoint?: string;

--- a/src/types/copilot.ts
+++ b/src/types/copilot.ts
@@ -115,6 +115,13 @@ export interface CopilotOptions {
    * If not specified, a default model will be used.
    */
   model?: CopilotModel | CustomCopilotModel;
+
+  /**
+   * The endpoint to use. Can be used to override the default endpoint for the provider, without using a custom model.
+   * Mainly for things like Azure OpenAI or other providers that have multiple endpoints.
+   * If not specified, a default endpoint will be used.
+   */
+  endpoint?: string;
 }
 
 export type CustomCopilotModel = {

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -7,7 +7,11 @@ import {
 } from './copilot';
 
 export interface ProviderHandler<T extends CopilotProvider> {
-  createEndpoint(model: PickCopilotModel<T>, apiKey: string): string;
+  createEndpoint(
+    endpoint: string | undefined,
+    model: PickCopilotModel<T>,
+    apiKey: string,
+  ): string;
   createRequestBody(
     model: PickCopilotModel<T>,
     prompt: PromptData,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Support for custom endpoints.

<!-- Why are these changes necessary? -->

**Why**:

Right now you can create custom API models, but it would be useful to have support for custom endpoints that use familiar API structures.

Examples include: Azure OpenAI, Vertex Studio, Ollama. There are all services that can create endpoints compatible with the OpenAI or Gemini API clients (or REST in this case). They are drop-in replacements that work simply by changing the endpoint URL, so implementing them through the customCopilot option would be needlessly hard. 

<!-- How were these changes implemented? -->

**How**:

I changed up the `createProviderEndpoint` method to support custom endpoints, and allowed for the user to input a custom endpoint in the Copilot class.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Probably not ready to merge. It may need tests, but I am unfamiliar with Vitest (I use Mocha).

I am happy to add documentation and fix bugs if needed though. 

<!-- feel free to add additional comments -->

Thanks!