### PR TITLE
fix: allow completions starting with whitespaces

### DIFF
--- a/packages/monacopilot/src/classes/formatter.ts
+++ b/packages/monacopilot/src/classes/formatter.ts
@@ -65,7 +65,7 @@ export class CompletionFormatter {
             result = result.replace(codeBlock, codeContent);
         }
 
-        return result.trim();
+        return result.replace(/^\n+|\n+$/g, '');
     }
 
     public removeExcessiveNewlines(): CompletionFormatter {

--- a/packages/monacopilot/tests/formatter.test.ts
+++ b/packages/monacopilot/tests/formatter.test.ts
@@ -115,6 +115,16 @@ describe('CompletionFormatter', () => {
             const result = formatter.removeMarkdownCodeSyntax().build();
             expect(result).toBe('```\nconst incomplete = true;');
         });
+
+        it('should keep starting whitespaces', () => {
+            const formatter = new CompletionFormatter(
+                ' 3.14159;',
+                MOCK_COMPLETION_POS.column,
+                '',
+            );
+            const result = formatter.removeMarkdownCodeSyntax().build();
+            expect(result).toBe(' 3.14159;');
+        });
     });
 
     describe('removeExcessiveNewlines', () => {


### PR DESCRIPTION
I use a model to complete code and it returns a completion which starts with a white space as such " 0.6". 
It's exactly what I expect, but the formatter trims initial whitespaces so it looks like this:
<img width="116" alt="image" src="https://github.com/user-attachments/assets/fcb7b3ea-0633-42fa-83eb-fd59e6a78624" />

And users have to manually insert a space if they accept the completion. 

So I made the formatter remove only the starting & ending \n. 

If performance is needed, we can avoid regex and do:
```
function trimNewlines(str) {
  let start = 0;
  let end = str.length;
  
  while (str[start] === '\n') start++;
  while (str[end - 1] === '\n') end--;
  
  return str.slice(start, end);
}
```

Also it might be worth still trimming everything at the end. As you see fit. 

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
