### PR TITLE
Fix/leading newlines

### DIFF
--- a/packages/monacopilot/src/classes/formatter.ts
+++ b/packages/monacopilot/src/classes/formatter.ts
@@ -64,8 +64,7 @@ export class CompletionFormatter {
             const codeContent = codeBlock.split('\n').slice(1, -1).join('\n');
             result = result.replace(codeBlock, codeContent);
         }
-
-        return result.replace(/^\n+|\n+$/g, '');
+        return result;
     }
 
     public removeExcessiveNewlines(): CompletionFormatter {

--- a/packages/monacopilot/tests/formatter.test.ts
+++ b/packages/monacopilot/tests/formatter.test.ts
@@ -125,6 +125,26 @@ describe('CompletionFormatter', () => {
             const result = formatter.removeMarkdownCodeSyntax().build();
             expect(result).toBe(' 3.14159;');
         });
+
+        it('should keep leading newlines', () => {
+            const formatter = new CompletionFormatter(
+                '\nconst PI = 3.14159;',
+                MOCK_COMPLETION_POS.column,
+                '',
+            );
+            const result = formatter.removeMarkdownCodeSyntax().build();
+            expect(result).toBe('\nconst PI = 3.14159;');
+        });
+
+        it('should preserve leading newline with code block', () => {
+            const formatter = new CompletionFormatter(
+                '\n```\nconst x = 5;\n```',
+                MOCK_COMPLETION_POS.column,
+                '',
+            );
+            const result = formatter.removeMarkdownCodeSyntax().build();
+            expect(result).toBe('\nconst x = 5;');
+        });
     });
 
     describe('removeExcessiveNewlines', () => {
@@ -180,6 +200,16 @@ describe('CompletionFormatter', () => {
             );
             const result = formatter.removeExcessiveNewlines().build();
             expect(result).toBe('\n\n');
+        });
+
+        it('should maintain single leading newline', () => {
+            const formatter = new CompletionFormatter(
+                '\nconst x = 10;\n\nconst y = 20;',
+                MOCK_COMPLETION_POS.column,
+                '',
+            );
+            const result = formatter.removeExcessiveNewlines().build();
+            expect(result).toBe('\nconst x = 10;\n\nconst y = 20;');
         });
     });
 


### PR DESCRIPTION
Closes https://github.com/arshad-yaseen/monacopilot/issues/110

**What**:
Fix leading newlines being incorrectly stripped from code completions when handling markdown code blocks.

**Why**:
When a code completion is meant to start on a new line (indicated by a leading `\n`), it was incorrectly being placed on the current line. This happened because `removeMarkdownCodeBlocks` was handling both markdown removal and newline cleanup, stripping legitimate leading newlines intended for code formatting.

**How**:
- Removed the newline cleanup logic since it's already handled by dedicated methods (`removeExcessiveNewlines` and `removeInvalidLineBreaks`)
- Added test case to verify leading newlines are preserved when removing markdown code blocks

**Checklist**:
- [x] Documentation - N/A (code is self-documenting)
- [x] Tests - Added new test case for leading newlines with markdown blocks
- [x] Ready to be merged - Yes, changes are minimal and well-tested