### PR TITLE
Remove styling from console logs

### DIFF
--- a/packages/core/src/llm/providers/mistral.ts
+++ b/packages/core/src/llm/providers/mistral.ts
@@ -50,7 +50,7 @@ export class MistralHandler extends BaseProviderHandler<'mistral'> {
         return Array.isArray(content)
             ? content
                   .filter(chunk => 'text' in chunk)
-                  .map(chunk => chunk.text)
+                  .map(chunk => (chunk as { text: string }).text)
                   .join('')
             : content;
     }

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,5 +1,3 @@
-const RED = '\x1b[91m';
-const YELLOW = '\x1b[93m';
 const RESET = '\x1b[0m';
 const BOLD = '\x1b[1m';
 

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -16,7 +16,7 @@ const parseErrorMessage = (error: unknown): string => {
 const report = (error: unknown): {message: string; stack?: string} => {
     const errorMessage = parseErrorMessage(error);
 
-    const formattedError = `${RED}${BOLD}[MONACOPILOT ERROR] ${errorMessage}${RESET}`;
+    const formattedError = `${BOLD}[MONACOPILOT ERROR] ${errorMessage}${RESET}`;
     console.error(formattedError);
 
     return {message: errorMessage};
@@ -24,7 +24,7 @@ const report = (error: unknown): {message: string; stack?: string} => {
 
 const warn = (message: string, error?: unknown): void => {
     console.warn(
-        `${YELLOW}${BOLD}[MONACOPILOT WARN] ${message}${error ? `\n${parseErrorMessage(error)}` : ''}${RESET}`,
+        `${BOLD}[MONACOPILOT WARN] ${message}${error ? `\n${parseErrorMessage(error)}` : ''}${RESET}`,
     );
 };
 
@@ -34,7 +34,7 @@ const warnDeprecated = (
     location?: string,
 ): void =>
     console.warn(
-        `${YELLOW}${BOLD}[MONACOPILOT DEPRECATED] "${oldFeature}" is deprecated${location ? ` in ${location}` : ''}. ` +
+        `${BOLD}[MONACOPILOT DEPRECATED] "${oldFeature}" is deprecated${location ? ` in ${location}` : ''}. ` +
             `Please use "${newFeature}" instead. It will be removed in a future version.${RESET}`,
     );
 


### PR DESCRIPTION
**What**:

Fixes: https://github.com/arshad-yaseen/monacopilot/issues/132

**Why**:

The error messages can be hard to read as they are yellow on a yellow background

**How**:

Removed all styling from logger

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] ~~Documentation~~
- [ ] ~~Tests~~
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
